### PR TITLE
Add an inlining cache invoker

### DIFF
--- a/api/src/main/scala/com/tersesystems/blindsight/InliningCacheInvoker.java
+++ b/api/src/main/scala/com/tersesystems/blindsight/InliningCacheInvoker.java
@@ -1,0 +1,73 @@
+package com.tersesystems.blindsight;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.*;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+
+import static java.lang.invoke.MethodHandles.*;
+import static java.lang.invoke.MethodType.methodType;
+
+// https://gist.github.com/forax/7bf08669f58804991fd45656a671c381
+class InliningCacheInvoker {
+  private InliningCacheInvoker() {
+    throw new AssertionError();
+  }
+  
+  static MethodHandle createInvoker(int depth, MethodType type) {
+    if (depth <= 0) {
+      throw new IllegalArgumentException("depth should be positive");
+    }
+    return new InliningCacheCallSite(type.insertParameterTypes(0, MethodHandle.class), depth).dynamicInvoker();
+  }
+  
+  private static class InliningCacheCallSite extends MutableCallSite {
+    private static final MethodHandle FALLBACK, TYPECHECK;
+    static {
+      Lookup lookup = lookup();
+      try {
+        FALLBACK = lookup.findVirtual(InliningCacheCallSite.class, "fallback",
+            methodType(MethodHandle.class, MethodHandle.class));
+        TYPECHECK = lookup.findStatic(InliningCacheCallSite.class, "typecheck",
+            methodType(boolean.class, MethodHandle.class, MethodHandle.class));
+      } catch (NoSuchMethodException | IllegalAccessException e) {
+        throw new AssertionError(e);
+      }
+    }
+    
+    private final InliningCacheCallSite head;
+    private final int depth;
+    
+    InliningCacheCallSite(MethodType type, int depth) {
+      super(type);
+      head = this;
+      this.depth = depth;
+      setTarget(foldArguments(exactInvoker(type), FALLBACK.bindTo(this)));
+    }
+    InliningCacheCallSite(MethodType type, InliningCacheCallSite head, int depth) {
+      super(type);
+      this.head = head;
+      this.depth = depth;
+      setTarget(foldArguments(exactInvoker(type), FALLBACK.bindTo(this)));
+    }
+    
+    @SuppressWarnings("unused")
+    private MethodHandle fallback(MethodHandle mh) {
+      MethodHandle target = MethodHandles.dropArguments(mh, 0, MethodHandle.class);
+      if (depth == 0) {  // inlining too deep
+        head.setTarget(exactInvoker(type().dropParameterTypes(0, 1)));
+        return target;
+      }
+      setTarget(MethodHandles.guardWithTest(TYPECHECK.bindTo(mh),
+          target,
+          new InliningCacheCallSite(type(), head, depth - 1).dynamicInvoker()));
+      return target;
+    }
+    
+    @SuppressWarnings("unused")
+    private static boolean typecheck(MethodHandle mh1, MethodHandle mh2) {
+      return mh1 == mh2;
+    }
+  }
+}

--- a/api/src/main/scala/com/tersesystems/blindsight/ParameterList.scala
+++ b/api/src/main/scala/com/tersesystems/blindsight/ParameterList.scala
@@ -16,10 +16,12 @@
 
 package com.tersesystems.blindsight
 
-import org.slf4j.Marker
-import org.slf4j.event.Level
+import java.lang.invoke.MethodHandles.lookup
+import java.lang.invoke.MethodType.methodType
+import java.lang.invoke.{MethodHandle, MethodType}
 
-import scala.collection.JavaConverters._
+import org.slf4j.{Logger, Marker}
+import org.slf4j.event.Level
 
 trait ParameterList {
 
@@ -29,40 +31,32 @@ trait ParameterList {
   def message(msg: String): Unit
   def messageArg1(msg: String, arg: Any): Unit
   def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit
-  def messageArgs(msg: String, args: Seq[_]): Unit
+  def messageArgs(msg: String, args: Array[Any]): Unit
   def markerMessage(marker: Marker, msg: String): Unit
   def markerMessageArg1(marker: Marker, msg: String, arg: Any): Unit
   def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit
-  def markerMessageArgs(marker: Marker, msg: String, args: Seq[_]): Unit
+  def markerMessageArgs(marker: Marker, msg: String, args: Array[Any]): Unit
 
-  def executeStatement(statement: Statement): Unit
+  def executeStatement(statement: Statement): Unit =
+    statement match {
+      case Statement(markers, message, args, None) =>
+        if (markers.isEmpty) {
+          messageArgs(message.toString, args.toArray)
+        } else {
+          markerMessageArgs(markers.marker, message.toString, args.toArray)
+        }
+
+      case Statement(markers, message, args, Some(exception)) =>
+        if (markers.isEmpty) {
+          messageArgs(message.toString, args.toArray :+ exception)
+        } else {
+          markerMessageArgs(markers.marker, message.toString, args.toArray :+ exception)
+        }
+    }
 }
 
 object ParameterList {
-
-  /**
-   * This is the calling site of the SLF4J method, where parameters and arguments meet.
-   *
-   * You should not need to use this as an end user, but it is very useful for extending loggers.
-   */
-  abstract class Impl(val level: Level, val logger: org.slf4j.Logger) extends ParameterList {
-    def executeStatement(statement: Statement): Unit =
-      statement match {
-        case Statement(markers, message, args, None) =>
-          if (markers.isEmpty) {
-            messageArgs(message.toString, args.toArray)
-          } else {
-            markerMessageArgs(markers.marker, message.toString, args.toArray)
-          }
-
-        case Statement(markers, message, args, Some(exception)) =>
-          if (markers.isEmpty) {
-            messageArgs(message.toString, args.toArray :+ exception)
-          } else {
-            markerMessageArgs(markers.marker, message.toString, args.toArray :+ exception)
-          }
-      }
-  }
+  // https://wiki.openjdk.java.net/display/HotSpot/Method+handle+invocation
 
   class Conditional(level: Level, core: CoreLogger) extends ParameterList {
 
@@ -80,7 +74,7 @@ object ParameterList {
     override def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit =
       if (core.condition(level, core.state))
         core.parameterList(level).messageArg1Arg2(msg, arg1, arg2)
-    override def messageArgs(msg: String, args: Seq[_]): Unit =
+    override def messageArgs(msg: String, args: Array[Any]): Unit =
       if (core.condition(level, core.state)) core.parameterList(level).messageArgs(msg, args)
     override def markerMessage(marker: Marker, msg: String): Unit =
       if (core.condition(level, core.state)) core.parameterList(level).markerMessage(marker, msg)
@@ -90,7 +84,7 @@ object ParameterList {
     override def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit =
       if (core.condition(level, core.state))
         core.parameterList(level).markerMessageArg1Arg2(marker, msg, arg1, arg2)
-    override def markerMessageArgs(marker: Marker, msg: String, args: Seq[_]): Unit =
+    override def markerMessageArgs(marker: Marker, msg: String, args: Array[Any]): Unit =
       if (core.condition(level, core.state))
         core.parameterList(level).markerMessageArgs(marker, msg, args)
 
@@ -110,102 +104,426 @@ object ParameterList {
       new ParameterList.Trace(logger)
     )
 
-  class Trace(logger: org.slf4j.Logger) extends Impl(Level.TRACE, logger) {
-    override def executePredicate(): Boolean = {
-      logger.isTraceEnabled()
+  object Invokers {
+    import InliningCacheInvoker.createInvoker
+
+    val predicate = createInvoker(3, methodType(classOf[Boolean], classOf[Logger]))
+    val predicateMarker =
+      createInvoker(3, methodType(classOf[Boolean], classOf[Logger], classOf[Marker]))
+
+    val message = createInvoker(3, methodType(classOf[Unit], classOf[Logger], classOf[String]))
+    val messageArg1 =
+      createInvoker(3, methodType(classOf[Unit], classOf[Logger], classOf[String], classOf[Object]))
+    val messageArg1Arg2 = createInvoker(
+      3,
+      methodType(classOf[Unit], classOf[Logger], classOf[String], classOf[Object], classOf[Object])
+    )
+    val messageArgs = createInvoker(
+      3,
+      methodType(classOf[Unit], classOf[Logger], classOf[String], classOf[Array[Object]])
+    )
+    val markerMessage =
+      createInvoker(3, methodType(classOf[Unit], classOf[Logger], classOf[Marker], classOf[String]))
+    val markerMessageArg1 = createInvoker(
+      3,
+      methodType(classOf[Unit], classOf[Logger], classOf[Marker], classOf[String], classOf[Object])
+    )
+    val markerMessageArg1Arg2 = createInvoker(
+      3,
+      methodType(
+        classOf[Unit],
+        classOf[Logger],
+        classOf[Marker],
+        classOf[String],
+        classOf[Object],
+        classOf[Object]
+      )
+    )
+    val markerMessageArgs = createInvoker(
+      3,
+      methodType(
+        classOf[Unit],
+        classOf[Logger],
+        classOf[Marker],
+        classOf[String],
+        classOf[Array[Object]]
+      )
+    )
+  }
+
+  object Types {
+    val message: MethodType     = methodType(classOf[Unit], classOf[String])
+    val messageArg1: MethodType = methodType(classOf[Unit], classOf[String], classOf[Object])
+    val messageArg1Arg2: MethodType =
+      methodType(classOf[Unit], classOf[String], classOf[Object], classOf[Object])
+    val messageArgs: MethodType = methodType(classOf[Unit], classOf[String], classOf[Array[Object]])
+
+    val markerMessage: MethodType = methodType(classOf[Unit], classOf[Marker], classOf[String])
+    val markerMessageArg1: MethodType =
+      methodType(classOf[Unit], classOf[Marker], classOf[String], classOf[Object])
+    val markerMessageArg1Arg2: MethodType =
+      methodType(classOf[Unit], classOf[Marker], classOf[String], classOf[Object], classOf[Object])
+    val markerMessageArgs: MethodType =
+      methodType(classOf[Unit], classOf[Marker], classOf[String], classOf[Array[Object]])
+  }
+
+  object Handles {
+    private def handlesFor(argType: MethodType): Array[MethodHandle] = {
+      def handleFor(level: Level): MethodHandle =
+        lookup.findVirtual(classOf[Logger], level.toString.toLowerCase, argType)
+
+      Level.values.sortBy(_.ordinal()).map(handleFor)
     }
-    override def executePredicate(marker: Marker): Boolean = {
-      logger.isTraceEnabled(marker)
-    }
 
-    override def message(msg: String): Unit               = logger.trace(msg)
-    override def messageArg1(msg: String, arg: Any): Unit = logger.trace(msg, arg)
-    override def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit =
-      logger.trace(msg, arg1, arg2)
-    override def messageArgs(msg: String, args: Seq[_]): Unit =
-      logger.trace(msg, args.asJava.toArray: _*)
-    override def markerMessage(marker: Marker, msg: String): Unit = logger.trace(marker, msg)
-    override def markerMessageArg1(marker: Marker, msg: String, arg: Any): Unit =
-      logger.trace(marker, msg, arg)
-    override def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit =
-      logger.trace(marker, msg, arg1, arg2)
-    override def markerMessageArgs(marker: Marker, msg: String, args: Seq[_]): Unit =
-      logger.trace(marker, msg, args.asJava.toArray: _*)
+    val message: Array[MethodHandle]         = handlesFor(Types.message)
+    val messageArg1: Array[MethodHandle]     = handlesFor(Types.messageArg1)
+    val messageArg1Arg2: Array[MethodHandle] = handlesFor(Types.messageArg1Arg2)
+    val messageArgs: Array[MethodHandle]     = handlesFor(Types.messageArgs)
+
+    val markerMessage: Array[MethodHandle]         = handlesFor(Types.markerMessage)
+    val markerMessageArg1: Array[MethodHandle]     = handlesFor(Types.markerMessageArg1)
+    val markerMessageArg1Arg2: Array[MethodHandle] = handlesFor(Types.markerMessageArg1Arg2)
+    val markerMessageArgs: Array[MethodHandle]     = handlesFor(Types.markerMessageArgs)
   }
 
-  class Debug(logger: org.slf4j.Logger) extends Impl(Level.DEBUG, logger) {
-    override def executePredicate(): Boolean               = logger.isDebugEnabled()
-    override def executePredicate(marker: Marker): Boolean = logger.isDebugEnabled(marker)
+  final class Trace(logger: org.slf4j.Logger) extends ParameterList {
 
-    override def message(msg: String): Unit               = logger.debug(msg)
-    override def messageArg1(msg: String, arg: Any): Unit = logger.debug(msg, arg)
-    override def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit =
-      logger.debug(msg, arg1, arg2)
-    override def messageArgs(msg: String, args: Seq[_]): Unit =
-      logger.debug(msg, args.asJava.toArray: _*)
-    override def markerMessage(marker: Marker, msg: String): Unit = logger.debug(marker, msg)
-    override def markerMessageArg1(marker: Marker, msg: String, arg: Any): Unit =
-      logger.debug(marker, msg, arg)
-    override def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit =
-      logger.debug(marker, msg, arg1, arg2)
-    override def markerMessageArgs(marker: Marker, msg: String, args: Seq[_]): Unit =
-      logger.debug(marker, msg, args.asJava.toArray: _*)
+    import Trace._
+
+    def executePredicate(): Boolean =
+      Invokers.predicate.invokeExact(predicateHandle, logger)
+
+    def executePredicate(marker: Marker): Boolean =
+      Invokers.predicateMarker.invokeExact(predicateMarkerHandle, logger, marker)
+
+    def message(msg: String): Unit =
+      Invokers.message.invokeExact(messageHandle, logger, msg)
+
+    def messageArg1(msg: String, arg: Any): Unit =
+      Invokers.messageArg1.invokeExact(messageArg1Handle, logger, msg, arg)
+
+    def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit =
+      Invokers.messageArg1Arg2.invokeExact(messageArg1Arg2Handle, logger, msg, arg1, arg2)
+
+    def messageArgs(msg: String, args: Array[Any]): Unit =
+      Invokers.messageArgs.invokeExact(messageArgsHandle, logger, msg, args.toArray)
+
+    def markerMessage(marker: Marker, msg: String): Unit =
+      Invokers.markerMessage.invokeExact(markerMessageHandle, logger, marker, msg)
+
+    def markerMessageArg1(marker: Marker, msg: String, arg: Any): Unit =
+      Invokers.markerMessageArg1.invokeExact(markerMessageArg1Handle, logger, marker, msg, arg)
+
+    def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit =
+      Invokers.markerMessageArg1Arg2.invokeExact(
+        markerMessageArg1Arg2Handle,
+        logger,
+        marker,
+        msg,
+        arg1,
+        arg2
+      )
+
+    def markerMessageArgs(marker: Marker, msg: String, args: Array[Any]): Unit =
+      Invokers.markerMessageArgs.invokeExact(
+        markerMessageArgsHandle,
+        logger,
+        marker,
+        msg,
+        args.toArray
+      )
   }
 
-  class Info(logger: org.slf4j.Logger) extends Impl(Level.INFO, logger) {
-    override def executePredicate(): Boolean               = logger.isInfoEnabled
-    override def executePredicate(marker: Marker): Boolean = logger.isInfoEnabled(marker)
+  object Trace {
+    private val predicateHandle =
+      lookup.findVirtual(classOf[Logger], "isTraceEnabled", methodType(classOf[Boolean]))
+    private val predicateMarkerHandle = lookup.findVirtual(
+      classOf[Logger],
+      "isTraceEnabled",
+      methodType(classOf[Boolean], classOf[Marker])
+    )
 
-    override def message(msg: String): Unit               = logger.info(msg)
-    override def messageArg1(msg: String, arg: Any): Unit = logger.info(msg, arg)
-    override def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit =
-      logger.info(msg, arg1, arg2)
-    override def messageArgs(msg: String, args: Seq[_]): Unit =
-      logger.info(msg, args.asJava.toArray: _*)
-    override def markerMessage(marker: Marker, msg: String): Unit = logger.info(marker, msg)
-    override def markerMessageArg1(marker: Marker, msg: String, arg: Any): Unit =
-      logger.info(marker, msg, arg)
-    override def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit =
-      logger.info(marker, msg, arg1, arg2)
-    override def markerMessageArgs(marker: Marker, msg: String, args: Seq[_]): Unit =
-      logger.info(marker, msg, args.asJava.toArray: _*)
+    private val levelIndex                  = Level.TRACE.ordinal()
+    private val messageHandle               = Handles.message(levelIndex)
+    private val messageArg1Handle           = Handles.messageArg1(levelIndex)
+    private val messageArg1Arg2Handle       = Handles.messageArg1Arg2(levelIndex)
+    private val messageArgsHandle           = Handles.messageArgs(levelIndex)
+    private val markerMessageHandle         = Handles.markerMessage(levelIndex)
+    private val markerMessageArg1Handle     = Handles.markerMessageArg1(levelIndex)
+    private val markerMessageArg1Arg2Handle = Handles.markerMessageArg1Arg2(levelIndex)
+    private val markerMessageArgsHandle     = Handles.markerMessageArgs(levelIndex)
   }
 
-  class Warn(logger: org.slf4j.Logger) extends Impl(Level.WARN, logger) {
-    override def executePredicate(): Boolean               = logger.isWarnEnabled()
-    override def executePredicate(marker: Marker): Boolean = logger.isWarnEnabled(marker)
+  final class Debug(logger: org.slf4j.Logger) extends ParameterList {
 
-    override def message(msg: String): Unit               = logger.warn(msg)
-    override def messageArg1(msg: String, arg: Any): Unit = logger.warn(msg, arg)
-    override def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit =
-      logger.warn(msg, arg1, arg2)
-    override def messageArgs(msg: String, args: Seq[_]): Unit =
-      logger.warn(msg, args.asJava.toArray: _*)
-    override def markerMessage(marker: Marker, msg: String): Unit = logger.warn(marker, msg)
-    override def markerMessageArg1(marker: Marker, msg: String, arg: Any): Unit =
-      logger.warn(marker, msg, arg)
-    override def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit =
-      logger.warn(marker, msg, arg1, arg2)
-    override def markerMessageArgs(marker: Marker, msg: String, args: Seq[_]): Unit =
-      logger.warn(marker, msg, args.asJava.toArray: _*)
+    import Debug._
+
+    def executePredicate(): Boolean =
+      Invokers.predicate.invokeExact(predicateHandle, logger)
+
+    def executePredicate(marker: Marker): Boolean =
+      Invokers.predicateMarker.invokeExact(predicateMarkerHandle, logger, marker)
+
+    def message(msg: String): Unit =
+      Invokers.message.invokeExact(messageHandle, logger, msg)
+
+    def messageArg1(msg: String, arg: Any): Unit =
+      Invokers.messageArg1.invokeExact(messageArg1Handle, logger, msg, arg)
+
+    def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit =
+      Invokers.messageArg1Arg2.invokeExact(messageArg1Arg2Handle, logger, msg, arg1, arg2)
+
+    def messageArgs(msg: String, args: Array[Any]): Unit =
+      Invokers.messageArgs.invokeExact(messageArgsHandle, logger, msg, args.toArray)
+
+    def markerMessage(marker: Marker, msg: String): Unit =
+      Invokers.markerMessage.invokeExact(markerMessageHandle, logger, marker, msg)
+
+    def markerMessageArg1(marker: Marker, msg: String, arg: Any): Unit =
+      Invokers.markerMessageArg1.invokeExact(markerMessageArg1Handle, logger, marker, msg, arg)
+
+    def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit =
+      Invokers.markerMessageArg1Arg2.invokeExact(
+        markerMessageArg1Arg2Handle,
+        logger,
+        marker,
+        msg,
+        arg1,
+        arg2
+      )
+
+    def markerMessageArgs(marker: Marker, msg: String, args: Array[Any]): Unit =
+      Invokers.markerMessageArgs.invokeExact(
+        markerMessageArgsHandle,
+        logger,
+        marker,
+        msg,
+        args.toArray
+      )
   }
 
-  class Error(logger: org.slf4j.Logger) extends Impl(Level.ERROR, logger) {
-    override def executePredicate(): Boolean               = logger.isErrorEnabled
-    override def executePredicate(marker: Marker): Boolean = logger.isErrorEnabled(marker)
+  object Debug {
+    private val predicateHandle =
+      lookup.findVirtual(classOf[Logger], "isDebugEnabled", methodType(classOf[Boolean]))
+    private val predicateMarkerHandle = lookup.findVirtual(
+      classOf[Logger],
+      "isDebugEnabled",
+      methodType(classOf[Boolean], classOf[Marker])
+    )
 
-    override def message(msg: String): Unit               = logger.error(msg)
-    override def messageArg1(msg: String, arg: Any): Unit = logger.error(msg, arg)
-    override def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit =
-      logger.error(msg, arg1, arg2)
-    override def messageArgs(msg: String, args: Seq[_]): Unit =
-      logger.error(msg, args.asJava.toArray: _*)
-    override def markerMessage(marker: Marker, msg: String): Unit = logger.error(marker, msg)
-    override def markerMessageArg1(marker: Marker, msg: String, arg: Any): Unit =
-      logger.error(marker, msg, arg)
-    override def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit =
-      logger.error(marker, msg, arg1, arg2)
-    override def markerMessageArgs(marker: Marker, msg: String, args: Seq[_]): Unit =
-      logger.error(marker, msg, args.asJava.toArray: _*)
+    private val levelIndex                  = Level.DEBUG.ordinal()
+    private val messageHandle               = Handles.message(levelIndex)
+    private val messageArg1Handle           = Handles.messageArg1(levelIndex)
+    private val messageArg1Arg2Handle       = Handles.messageArg1Arg2(levelIndex)
+    private val messageArgsHandle           = Handles.messageArgs(levelIndex)
+    private val markerMessageHandle         = Handles.markerMessage(levelIndex)
+    private val markerMessageArg1Handle     = Handles.markerMessageArg1(levelIndex)
+    private val markerMessageArg1Arg2Handle = Handles.markerMessageArg1Arg2(levelIndex)
+    private val markerMessageArgsHandle     = Handles.markerMessageArgs(levelIndex)
   }
+
+  final class Info(logger: org.slf4j.Logger) extends ParameterList {
+
+    import Info._
+
+    def executePredicate(): Boolean =
+      Invokers.predicate.invokeExact(predicateHandle, logger)
+
+    def executePredicate(marker: Marker): Boolean =
+      Invokers.predicateMarker.invokeExact(predicateMarkerHandle, logger, marker)
+
+    def message(msg: String): Unit =
+      Invokers.message.invokeExact(messageHandle, logger, msg)
+
+    def messageArg1(msg: String, arg: Any): Unit =
+      Invokers.messageArg1.invokeExact(messageArg1Handle, logger, msg, arg)
+
+    def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit =
+      Invokers.messageArg1Arg2.invokeExact(messageArg1Arg2Handle, logger, msg, arg1, arg2)
+
+    def messageArgs(msg: String, args: Array[Any]): Unit =
+      Invokers.messageArgs.invokeExact(messageArgsHandle, logger, msg, args.toArray)
+
+    def markerMessage(marker: Marker, msg: String): Unit =
+      Invokers.markerMessage.invokeExact(markerMessageHandle, logger, marker, msg)
+
+    def markerMessageArg1(marker: Marker, msg: String, arg: Any): Unit =
+      Invokers.markerMessageArg1.invokeExact(markerMessageArg1Handle, logger, marker, msg, arg)
+
+    def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit =
+      Invokers.markerMessageArg1Arg2.invokeExact(
+        markerMessageArg1Arg2Handle,
+        logger,
+        marker,
+        msg,
+        arg1,
+        arg2
+      )
+
+    def markerMessageArgs(marker: Marker, msg: String, args: Array[Any]): Unit =
+      Invokers.markerMessageArgs.invokeExact(
+        markerMessageArgsHandle,
+        logger,
+        marker,
+        msg,
+        args
+      )
+  }
+
+  object Info {
+    private val predicateHandle =
+      lookup.findVirtual(classOf[Logger], "isInfoEnabled", methodType(classOf[Boolean]))
+    private val predicateMarkerHandle = lookup.findVirtual(
+      classOf[Logger],
+      "isInfoEnabled",
+      methodType(classOf[Boolean], classOf[Marker])
+    )
+
+    private val levelIndex                  = Level.INFO.ordinal()
+    private val messageHandle               = Handles.message(levelIndex)
+    private val messageArg1Handle           = Handles.messageArg1(levelIndex)
+    private val messageArg1Arg2Handle       = Handles.messageArg1Arg2(levelIndex)
+    private val messageArgsHandle           = Handles.messageArgs(levelIndex)
+    private val markerMessageHandle         = Handles.markerMessage(levelIndex)
+    private val markerMessageArg1Handle     = Handles.markerMessageArg1(levelIndex)
+    private val markerMessageArg1Arg2Handle = Handles.markerMessageArg1Arg2(levelIndex)
+    private val markerMessageArgsHandle     = Handles.markerMessageArgs(levelIndex)
+  }
+
+  final class Warn(logger: org.slf4j.Logger) extends ParameterList {
+
+    import Warn._
+
+    def executePredicate(): Boolean =
+      Invokers.predicate.invokeExact(predicateHandle, logger)
+
+    def executePredicate(marker: Marker): Boolean =
+      Invokers.predicateMarker.invokeExact(predicateMarkerHandle, logger, marker)
+
+    def message(msg: String): Unit =
+      Invokers.message.invokeExact(messageHandle, logger, msg)
+
+    def messageArg1(msg: String, arg: Any): Unit =
+      Invokers.messageArg1.invokeExact(messageArg1Handle, logger, msg, arg)
+
+    def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit =
+      Invokers.messageArg1Arg2.invokeExact(messageArg1Arg2Handle, logger, msg, arg1, arg2)
+
+    def messageArgs(msg: String, args: Array[Any]): Unit =
+      Invokers.messageArgs.invokeExact(messageArgsHandle, logger, msg, args.toArray)
+
+    def markerMessage(marker: Marker, msg: String): Unit =
+      Invokers.markerMessage.invokeExact(markerMessageHandle, logger, marker, msg)
+
+    def markerMessageArg1(marker: Marker, msg: String, arg: Any): Unit =
+      Invokers.markerMessageArg1.invokeExact(markerMessageArg1Handle, logger, marker, msg, arg)
+
+    def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit =
+      Invokers.markerMessageArg1Arg2.invokeExact(
+        markerMessageArg1Arg2Handle,
+        logger,
+        marker,
+        msg,
+        arg1,
+        arg2
+      )
+
+    def markerMessageArgs(marker: Marker, msg: String, args: Array[Any]): Unit =
+      Invokers.markerMessageArgs.invokeExact(
+        markerMessageArgsHandle,
+        logger,
+        marker,
+        msg,
+        args.toArray
+      )
+  }
+
+  object Warn {
+    private val predicateHandle =
+      lookup.findVirtual(classOf[Logger], "isWarnEnabled", methodType(classOf[Boolean]))
+    private val predicateMarkerHandle = lookup.findVirtual(
+      classOf[Logger],
+      "isWarnEnabled",
+      methodType(classOf[Boolean], classOf[Marker])
+    )
+
+    private val levelIndex                  = Level.WARN.ordinal()
+    private val messageHandle               = Handles.message(levelIndex)
+    private val messageArg1Handle           = Handles.messageArg1(levelIndex)
+    private val messageArg1Arg2Handle       = Handles.messageArg1Arg2(levelIndex)
+    private val messageArgsHandle           = Handles.messageArgs(levelIndex)
+    private val markerMessageHandle         = Handles.markerMessage(levelIndex)
+    private val markerMessageArg1Handle     = Handles.markerMessageArg1(levelIndex)
+    private val markerMessageArg1Arg2Handle = Handles.markerMessageArg1Arg2(levelIndex)
+    private val markerMessageArgsHandle     = Handles.markerMessageArgs(levelIndex)
+  }
+
+  final class Error(logger: org.slf4j.Logger) extends ParameterList {
+
+    import Error._
+
+    def executePredicate(): Boolean =
+      Invokers.predicate.invokeExact(predicateHandle, logger)
+
+    def executePredicate(marker: Marker): Boolean =
+      Invokers.predicateMarker.invokeExact(predicateMarkerHandle, logger, marker)
+
+    def message(msg: String): Unit =
+      Invokers.message.invokeExact(messageHandle, logger, msg)
+
+    def messageArg1(msg: String, arg: Any): Unit =
+      Invokers.messageArg1.invokeExact(messageArg1Handle, logger, msg, arg)
+
+    def messageArg1Arg2(msg: String, arg1: Any, arg2: Any): Unit =
+      Invokers.messageArg1Arg2.invokeExact(messageArg1Arg2Handle, logger, msg, arg1, arg2)
+
+    def messageArgs(msg: String, args: Array[Any]): Unit =
+      Invokers.messageArgs.invokeExact(messageArgsHandle, logger, msg, args.toArray)
+
+    def markerMessage(marker: Marker, msg: String): Unit =
+      Invokers.markerMessage.invokeExact(markerMessageHandle, logger, marker, msg)
+
+    def markerMessageArg1(marker: Marker, msg: String, arg: Any): Unit =
+      Invokers.markerMessageArg1.invokeExact(markerMessageArg1Handle, logger, marker, msg, arg)
+
+    def markerMessageArg1Arg2(marker: Marker, msg: String, arg1: Any, arg2: Any): Unit =
+      Invokers.markerMessageArg1Arg2.invokeExact(
+        markerMessageArg1Arg2Handle,
+        logger,
+        marker,
+        msg,
+        arg1,
+        arg2
+      )
+
+    def markerMessageArgs(marker: Marker, msg: String, args: Array[Any]): Unit =
+      Invokers.markerMessageArgs.invokeExact(
+        markerMessageArgsHandle,
+        logger,
+        marker,
+        msg,
+        args.toArray
+      )
+  }
+
+  object Error {
+    private val predicateHandle =
+      lookup.findVirtual(classOf[Logger], "isErrorEnabled", methodType(classOf[Boolean]))
+    private val predicateMarkerHandle = lookup.findVirtual(
+      classOf[Logger],
+      "isErrorEnabled",
+      methodType(classOf[Boolean], classOf[Marker])
+    )
+
+    private val levelIndex                  = Level.ERROR.ordinal()
+    private val messageHandle               = Handles.message(levelIndex)
+    private val messageArg1Handle           = Handles.messageArg1(levelIndex)
+    private val messageArg1Arg2Handle       = Handles.messageArg1Arg2(levelIndex)
+    private val messageArgsHandle           = Handles.messageArgs(levelIndex)
+    private val markerMessageHandle         = Handles.markerMessage(levelIndex)
+    private val markerMessageArg1Handle     = Handles.markerMessageArg1(levelIndex)
+    private val markerMessageArg1Arg2Handle = Handles.markerMessageArg1Arg2(levelIndex)
+    private val markerMessageArgsHandle     = Handles.markerMessageArgs(levelIndex)
+  }
+
 }


### PR DESCRIPTION
Fixes https://github.com/tersesystems/blindsight/issues/94 by adding an inlining cache invoker.  This is too much gun right now as we're not caching method handles to any depth, but it's fun that we can call logger.debug directly through the method handle without going through inlining.

I think that the reason that the predicate guard takes 3.5 ns as opposed to the 1.3 ns from `slf4jLogger.isLoggingDebug` is because we're calling two methods: `logger.simplePredicate().apply()`.  If we can get the inlining to short circut that, it could be a win.