### PR TITLE
Fix warnings in compile

### DIFF
--- a/api/src/main/scala/com/tersesystems/blindsight/ParameterList.scala
+++ b/api/src/main/scala/com/tersesystems/blindsight/ParameterList.scala
@@ -19,7 +19,7 @@ package com.tersesystems.blindsight
 import org.slf4j.Marker
 import org.slf4j.event.Level
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 trait ParameterList {
 
@@ -53,13 +53,13 @@ object ParameterList {
             if (args.isEmpty) {
               message(m.toString)
             } else {
-              messageArgs(m.toString, args.toArray)
+              messageArgs(m.toString, args.toSeq)
             }
           } else {
             if (args.isEmpty) {
               markerMessage(markers.marker, m.toString)
             } else {
-              markerMessageArgs(markers.marker, m.toString, args.toArray)
+              markerMessageArgs(markers.marker, m.toString, args.toSeq)
             }
           }
 
@@ -68,13 +68,13 @@ object ParameterList {
             if (args.isEmpty) {
               messageArg1(m.toString, exception)
             } else {
-              messageArgs(m.toString, args.toArray :+ exception)
+              messageArgs(m.toString, args.toSeq :+ exception)
             }
           } else {
             if (args.isEmpty) {
               markerMessageArg1(markers.marker, m.toString, exception)
             } else {
-              markerMessageArgs(markers.marker, m.toString, args.toArray :+ exception)
+              markerMessageArgs(markers.marker, m.toString, args.toSeq :+ exception)
             }
           }
       }

--- a/api/src/main/scala/com/tersesystems/blindsight/slf4j/StrictSLF4JMethod.scala
+++ b/api/src/main/scala/com/tersesystems/blindsight/slf4j/StrictSLF4JMethod.scala
@@ -206,7 +206,7 @@ object StrictSLF4JMethod {
         args: Arguments
     )(implicit line: Line, file: File, enclosing: Enclosing): Unit = {
       if (shouldLog)
-        markerMessageArgs(markersPlusSource.marker, message.toString, args.toArray)
+        markerMessageArgs(markersPlusSource.marker, message.toString, args.toSeq)
     }
 
     override def apply(
@@ -215,7 +215,7 @@ object StrictSLF4JMethod {
         throwable: Throwable
     )(implicit line: Line, file: File, enclosing: Enclosing): Unit = {
       if (shouldLog) {
-        markerMessageArgs(markersPlusSource.marker, message.toString, args.toArray :+ throwable)
+        markerMessageArgs(markersPlusSource.marker, message.toString, args.toSeq :+ throwable)
       }
     }
 
@@ -311,7 +311,7 @@ object StrictSLF4JMethod {
     )(implicit line: Line, file: File, enclosing: Enclosing): Unit = {
       val m = markersPlusSource(markers)
       if (executePredicate(m.marker)) {
-        markerMessageArgs(m.marker, message.toString, args.toArray)
+        markerMessageArgs(m.marker, message.toString, args.toSeq)
       }
     }
 
@@ -323,7 +323,7 @@ object StrictSLF4JMethod {
     )(implicit line: Line, file: File, enclosing: Enclosing): Unit = {
       val m = markersPlusSource(markers)
       if (executePredicate(m.marker)) {
-        markerMessageArgs(m.marker, message.toString, args.toArray :+ throwable)
+        markerMessageArgs(m.marker, message.toString, args.toSeq :+ throwable)
       }
     }
 

--- a/api/src/main/scala/com/tersesystems/blindsight/slf4j/UncheckedSLF4JMethod.scala
+++ b/api/src/main/scala/com/tersesystems/blindsight/slf4j/UncheckedSLF4JMethod.scala
@@ -187,11 +187,11 @@ object UncheckedSLF4JMethod {
       val markers = collateMarkers
       if (markers.nonEmpty) {
         if (executePredicate(markers.marker)) {
-          markerMessageArgs(markers.marker, format, args.toArray)
+          markerMessageArgs(markers.marker, format, args.toSeq)
         }
       } else {
         if (executePredicate()) {
-          messageArgs(format, args.toArray)
+          messageArgs(format, args.toSeq)
         }
       }
     }
@@ -241,7 +241,7 @@ object UncheckedSLF4JMethod {
       )
       val markers = collateMarkers(marker)
       if (executePredicate(markers.marker)) {
-        markerMessageArgs(markers.marker, format, (args.toArray))
+        markerMessageArgs(markers.marker, format, args.toSeq)
       }
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -226,6 +226,7 @@ lazy val api = (project in file("api"))
     ),
     libraryDependencies += slf4jApi,
     libraryDependencies += sourcecode,
+    libraryDependencies += scalaCollectionCompat,
     libraryDependencies += scalaTest              % Test,
     libraryDependencies += scalaJava8Compat       % Test,
     libraryDependencies += logbackClassic         % Test,

--- a/logstash/src/main/scala/com/tersesystems/blindsight/logstash/BObjectConverters.scala
+++ b/logstash/src/main/scala/com/tersesystems/blindsight/logstash/BObjectConverters.scala
@@ -19,7 +19,7 @@ package com.tersesystems.blindsight.logstash
 object BObjectConverters {
   import com.tersesystems.blindsight.AST._
 
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   def asJava(bobj: BObject): java.util.Map[String, Any] = {
     bobj.obj

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,9 +8,12 @@ object Dependencies {
 
   lazy val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.30"
 
-  lazy val sourcecode = "com.lihaoyi"         %% "sourcecode" % "0.2.1"
-  lazy val janino     = "org.codehaus.janino"  % "janino"     % "3.0.11"
-  lazy val jansi      = "org.fusesource.jansi" % "jansi"      % "1.17.1"
+  // import scala.jdk.CollectionConverters._
+  // https://github.com/scala/scala-library-compat/pull/217
+  lazy val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6"
+  lazy val sourcecode            = "com.lihaoyi"            %% "sourcecode"              % "0.2.1"
+  lazy val janino                = "org.codehaus.janino"     % "janino"                  % "3.0.11"
+  lazy val jansi                 = "org.fusesource.jansi"    % "jansi"                   % "1.17.1"
 
   lazy val logbackBudget      = "com.tersesystems.logback" % "logback-budget"      % terseLogback
   lazy val logbackTurboMarker = "com.tersesystems.logback" % "logback-turbomarker" % terseLogback


### PR DESCRIPTION
2.13 wants to use a different converters package, so we include `scala-collection-compat` to backport to 2.12 and 2.11.